### PR TITLE
fix back-edge error

### DIFF
--- a/bpf/qos_tc.c
+++ b/bpf/qos_tc.c
@@ -95,6 +95,7 @@ static __always_inline __u64 get_average_rate(__u32 direction) {
 	__u64 cur_rate = 0;
 	__u32 index    = index_shift(direction);
 
+    #pragma unroll
 	for (i = 0; i < 9; i++) {
 		struct net_stat *info;
 		index += i;


### PR DESCRIPTION
hi, i meet some errors in compile `qos_tc.c `, logs as below:
```bash
I1123 14:42:17.468779 1463510 damon.go:65] version: main/v0.0.0 (linux/amd64) $Format:%H$ 1970-01-01T00:00:00Z
I1123 14:42:17.469791 1463510 compile.go:56] bpf "msg"="exec" "cmd"="/bin/clang -g -O2 -target bpf -std=gnu99 -I/var/lib/terway/headers -DFEAT_EDT=1 -c /var/lib/terway/src/qos_tc.c -o /var/lib/terway/qos_tc.o"
E1123 14:42:17.715842 1463510 mamager.go:98] bpf "msg"="load bpf objects failed" "error"="field QosGlobal: program qos_global: load program: invalid argument: back-edge from insn 278 to 279 (2 line(s) omitted)"
exit status 1
```

kernel version:
Linux version 5.10.134-14.an8.x86_64