### PR TITLE
support cgroup driver is cgroupfs

### DIFF
--- a/pkg/config/syncer.go
+++ b/pkg/config/syncer.go
@@ -276,7 +276,6 @@ func (s *Syncer) syncCgroupRate() error {
 		err = s.bpf.DeleteCgroupRate(id)
 		if err != nil {
 			log.Error(err, "delete cgruop rate failed", "id", strconv.Itoa(int(id)))
-			continue
 		}
 	}
 

--- a/pkg/k8s/pods.go
+++ b/pkg/k8s/pods.go
@@ -147,27 +147,17 @@ func (r *reconcilePod) Reconcile(ctx context.Context, request reconcile.Request)
 }
 
 func getIPs(pod *corev1.Pod) (v4 netip.Addr, v6 netip.Addr) {
-	if len(pod.Status.PodIPs) == 2 {
-		addr, _ := netip.ParseAddr(pod.Status.PodIPs[0].IP)
+	for _, ip := range pod.Status.PodIPs {
+		addr, err := netip.ParseAddr(ip.IP)
+		if err != nil {
+			continue
+		}
 		if addr.Is4() {
 			v4 = addr
 		} else {
 			v6 = addr
 		}
-		addr, _ = netip.ParseAddr(pod.Status.PodIPs[1].IP)
-		if addr.Is4() {
-			v4 = addr
-		} else {
-			v6 = addr
-		}
-	} else {
-		addr, _ := netip.ParseAddr(pod.Status.PodIP)
-		if addr.Is4() {
-			v4 = addr
-			return
-		}
-		v6 = addr
-		return
 	}
+
 	return
 }


### PR DESCRIPTION
This pr did two things.
1. some code optimisation
2.  support cgroup driver is cgroupfs
```bash
[root@docker82 liuming6]# ls /sys/fs/cgroup/net_cls
cgroup.clone_children  cgroup.sane_behavior  kubepods         net_prio.ifpriomap  notify_on_release  release_agent
cgroup.procs           docker                net_cls.classid  net_prio.prioidx    pool_size          tasks
[root@docker82 liuming6]#
```
Here we can see that the pod-related cgroups are all in the /sys/fs/cgroup/${type}/kubepods/ directory, but only the cgroup information under kubepods.slice was processed previously