### PR TITLE
fix some syntax error in monitor.bt

### DIFF
--- a/bpf/monitor.bt
+++ b/bpf/monitor.bt
@@ -62,11 +62,13 @@ kprobe:start_xmit
     }
 
     if ($skb->priority ==0) {
-        @l0_bytes = @l0_bytes + $skb->len;
-    } else if ($skb->priority ==1) {
-        @l1_bytes = @l1_bytes + $skb->len;
-    }else if($skb->priority ==2) {
-        @l2_bytes = @l2_bytes + $skb->len;
+        @l0_bytes += $skb->len;
+    }
+    if ($skb->priority ==1) {
+        @l1_bytes += $skb->len;
+    }
+    if ($skb->priority ==2) {
+        @l2_bytes += $skb->len;
     }
 
 }


### PR DESCRIPTION
here we can see some syntax error when run `bpftrace monitor.bt`
![截屏2023-12-06 10 36 38](https://github.com/AliyunContainerService/terway-qos/assets/32814765/420874cd-5444-45ea-8728-661dc99b6955)

and i find some usage about this:
https://github.com/iovisor/bpftrace/blob/289f0c7e028b2317aeddbb0228d542f6250fe08c/docs/reference_guide.md?plain=1#L781-L793
maybe `else if` is not supported.