### PR TITLE
fix: elements in a pod-map are not deleted when pod is deleted

### DIFF
--- a/pkg/config/syncer.go
+++ b/pkg/config/syncer.go
@@ -143,11 +143,12 @@ func (s *Syncer) DeletePod(id string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	err := s.podCache.DelByPodID(id)
-	if err != nil {
+	podConfig := s.podCache.ByPodID(id)
+	if err := s.podCache.DelByPodID(id); err != nil {
 		return err
 	}
-	return s.bpf.DeletePodInfo(&types.PodConfig{PodID: id})
+
+	return s.bpf.DeletePodInfo(podConfig)
 }
 
 func (s *Syncer) UpdatePod(config *types.PodConfig) error {

--- a/pkg/k8s/pods.go
+++ b/pkg/k8s/pods.go
@@ -95,13 +95,10 @@ func (r *reconcilePod) Reconcile(ctx context.Context, request reconcile.Request)
 		Name:      request.Name,
 	}, &pod)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || pod.DeletionTimestamp != nil {
 			return reconcile.Result{}, r.syncer.DeletePod(request.String())
 		}
 		return reconcile.Result{}, err
-	}
-	if !pod.DeletionTimestamp.IsZero() {
-		return reconcile.Result{}, r.syncer.DeletePod(request.String())
 	}
 
 	v4, v6 := getIPs(&pod)


### PR DESCRIPTION
background:
`pod-map` not synced when pod is deleted.

here we can see some logics about delete pod ip from `pod-map`:
https://github.com/AliyunContainerService/terway-qos/blob/main/pkg/bpf/maps.go#L188-L205

it's based on `pod.ip`