### PR TITLE
fix：nil pointer panic

### DIFF
--- a/pkg/config/syncer.go
+++ b/pkg/config/syncer.go
@@ -152,6 +152,10 @@ func (s *Syncer) DeletePod(id string) error {
 	defer s.lock.Unlock()
 
 	podConfig := s.podCache.ByPodID(id)
+	if podConfig == nil {
+		return nil
+	}
+
 	if err := s.podCache.DelByPodID(id); err != nil {
 		return err
 	}


### PR DESCRIPTION
intermittent panic when using image v0.3.2

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x14d48da]
goroutine 607 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:119 +0x1e5
panic({0x16e39c0?, 0x2803ad0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/AliyunContainerService/terway-qos/pkg/bpf.(*Writer).DeletePodInfo(0xc000396ab0?, 0x15fd800?)
	/go/src/qos/pkg/bpf/maps.go:201 +0x1a
github.com/AliyunContainerService/terway-qos/pkg/config.(*Syncer).DeletePod(0xc0000b4960, {0xc000fa3dd0, 0x22})
	/go/src/qos/pkg/config/syncer.go:159 +0x157
github.com/AliyunContainerService/terway-qos/pkg/k8s.(*reconcilePod).Reconcile(0xc000198240, {0x1b7aa18, 0xc000c96360}, {{{0xc0003e89ed?, 0x0?}, {0xc000d0fe40?, 0x410605?}}})
	/go/src/qos/pkg/k8s/pods.go:99 +0x165
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1b7aa18?, {0x1b7aa18?, 0xc000c96360?}, {{{0xc0003e89ed?, 0x1634920?}, {0xc000d0fe40?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:122 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0007ace60, {0x1b7aa50, 0xc000db38b0}, {0x173ef00?, 0xc000241d40?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:323 +0x345
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007ace60, {0x1b7aa50, 0xc000db38b0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 589
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:231 +0x565